### PR TITLE
Workshop Report

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -40,6 +40,7 @@ website:
         - workshopsummary/index.qmd
         - workshopsummary/summary.qmd
         - workshopsummary/brief.qmd
+        - workshopsummary/report.qmd
 
     - id: ci-handbook
       title: "CI Handbook"

--- a/workshopsummary/brief.qmd
+++ b/workshopsummary/brief.qmd
@@ -1,6 +1,6 @@
 ---
 title: "{{< fa arrow-right >}} EFI-CI Briefing Paper"
-author: "Cameron Thompson"
+author: "Cameron Thompson, Jacob Zwart, Jake Kritzer, Chris Brown, Jessica Burnett, Mike Dietze, Jody Peters, Hassan Moustahfid"
 format:
   html:
     toc: true

--- a/workshopsummary/brief.qmd
+++ b/workshopsummary/brief.qmd
@@ -1,5 +1,6 @@
 ---
 title: "{{< fa arrow-right >}} EFI-CI Briefing Paper"
+author: "Cameron Thompson"
 format:
   html:
     toc: true

--- a/workshopsummary/report.qmd
+++ b/workshopsummary/report.qmd
@@ -1,0 +1,46 @@
+---
+title: "{{< fa arrow-right >}} EFI-CI Workshop Report"
+format:
+  html:
+    toc: true
+    toc-depth: 3
+    toc-position: left
+    comments:
+      utterances:
+         repo: eco4cast/efi-ci-workshop-2024
+---
+This report provides a brief overview of the recommendations from the 2024 Cyberinfrastructure (CI) workshop, with links to relevant documentation for further details.
+
+# Workshop Goals
+
+The goal of the 2024 workshop was to develop CI design principles and best practices for ecological forecasts across diverse spatiotemporal domains. By bringing together [researchers and CI experts](../reference/participants.qmd) from government agencies, academia, the private sector, and NGOs, the workshop aimed to:  
+1. Collate common CI practices across existing forecasting projects  
+2. Identify CI needs and gaps  
+3. Propose CI designs for a range of ecological forecasting challenges  
+
+# Recommendations
+
+The workshop was founded on the premise that ecological forecasting CI lacks widely accepted design principles. While participants generally agreed with the [best practices presented](summary.qmd#workflows-and-best-practices-breakout-group-discussions)—aligning with current literature—barriers to adoption persist. These challenges are primarily rooted in human factors, organizational culture, and limited institutional resources. To address these issues, we recommend the following:
+
+1. **Develop compelling communication materials** in collaboration with scientific societies, including:
+   a. White papers explaining the importance of ecological forecasting and CI 
+   b. Case studies highlighting the successes of ecological forecasting  
+   c. Flagship projects that can drive substantial impact and visibility for ecological forecasting community
+2. **Find and empower champions** at various levels within agencies and equip them with communication tools noted in Recommendation 1. 
+3. **Build communities of practice** by:
+   a. Participating in workshops (e.g., [2024 EFI CI Workshop](summary.qmd)) and conferences to promote CI best practices  
+   b. Providing tools, training, and platforms that foster collaboration (e.g., [CI handbook](../ci_handbook/index.qmd))
+4. **Expand the workforce and bridge expertise** 
+   a. Collaborate with academic partners to modernize curricula, develop core CI competencies, and create professional development opportunities with non-academic organizations
+5. **Align with agency missions and priorities** to gain traction in a resource-constrained environment by:
+   a. Reframing ecological forecasting in terms of societal priorities, such as economic development, public health, food and water security, hazard resilience, and environmental justice  
+   b. Capitalizing on strategic opportunities like high-profile initiatives, administration transitions, and budget cycles  
+6. **Advocate for ecological forecasting CI** by working with scientific societies, stakeholder groups, and boundary organizations to translate needs, priorities, and opportunities effectively  
+
+# Brief Workshop Summary
+Through presentations, panels, and breakout sessions, participants discussed workflows, best practices, and the implementation of cyberinfrastructure across agencies. While technical presentations were included, the diverse backgrounds of the participants shaped the scope of discussions, with a stronger focus on high-level concepts and general design rather than specific technical details. Many of the recommendations echoed those found in the literature, such as the [FAIR principles](../reference/EFI_CI_reference.qmd#fair-principles). Additionally, the participants' varied experiences highlighted the [numerous challenges that hinder the adoption](summary.qmd#breakout-group-discussions---synthesize-common-gaps-barriers-and-other-challenges-and-strategies-for-overcoming-them) of best practices and the advancement of ecological forecasting (refer to [Recommendations](#recommendations) above). 
+
+Higher-level [CI design best practices](summary.qmd#propose-generalized-cyberinfrastructure-design-for-ecological-forecasting) emphasized standards, interoperability, scalable architecture, open-source technologies, cataloging, and were grounded in design justice principles and co-development of CI products.
+
+As we build on these best practices into a [CI handbook](../ci_handbook/index.qmd), we invite contributions and feedback from both new and experienced forecasters. Please refer to the homepage for details on [how to contribute](../index.qmd#how-to-contribute) to this project.
+


### PR DESCRIPTION
Adds in a brief workshop report with recommendations at the top and brief summary and link to more details towards the bottom of the page. 

You have to preview the build locally if you want to see the website render with this proposed addition.  I have an issue open #7 to automatically build a preview website but haven't gotten to that yet. 

Current website is here https://projects.ecoforecast.org/efi-ci-workshop-2024/ 