### PR TITLE
GHA to shrink image file size before building website

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -9,11 +9,61 @@ on:
       - main  
   workflow_dispatch:
 
+env:
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+
 jobs:
-  build-deploy:
+  reduce-images:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    
+    - name: Check for large image files
+      id: large-img-check
+      run: |
+        img_path=$(du -ah --threshold=1M | awk '/.(JPE?G|jpe?g|PNG|png|HEIC|heic)$/ {print $2}') 
+        if [[ -n "$img_path" ]]; then
+          echo "big_image=true" >> $GITHUB_OUTPUT
+          echo "img_path=$(echo $img_path)" >> $GITHUB_OUTPUT
+        fi
+        
+    - name: Install ImageMagick
+      if: steps.large-img-check.outputs.big_image == 'true'
+      run: |
+        cd ..
+        wget https://imagemagick.org/archive/binaries/magick -o /magick
+        chmod +x /magick
+
+    - name: Shrink images
+      if: steps.large-img-check.outputs.big_image == 'true'
+      env:
+        img_path: ${{ steps.large-img-check.outputs.img_path }}
+      run: |
+        for image in $img_path; do
+          mogrify -resize 800x800 -quality 75 "$image"
+        done
+      #   Body width in Quarto documents is 800 px by default
+      #   https://quarto.org/docs/output-formats/page-layout.html#html-page-layout
+      #   ImageMagick mogrify docs: https://imagemagick.org/script/mogrify.php
+    
+    
+    - name: Push changes
+      if: steps.large-img-check.outputs.big_image == 'true'
+      run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add --all
+          git commit --allow-empty -m "[auto] Reduce image file size"
+          git push
+
+
+    
+  build-deploy:
+    needs: reduce-images
+    runs-on: ubuntu-latest
     container: eco4cast/rocker-neon4cast:latest
       
     steps:

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -43,7 +43,7 @@ jobs:
         img_path: ${{ steps.large-img-check.outputs.img_path }}
       run: |
         for image in $img_path; do
-          mogrify -resize 800x800 -quality 75 "$image"
+          mogrify -resize 800 -quality 75 "$image"
         done
       #   Body width in Quarto documents is 800 px by default
       #   https://quarto.org/docs/output-formats/page-layout.html#html-page-layout

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -24,18 +24,18 @@ jobs:
     - name: Check for large image files
       id: large-img-check
       run: |
-        img_path=$(du -ah --threshold=1M | awk '/.(JPE?G|jpe?g|PNG|png|HEIC|heic)$/ {print $2}') 
+        img_path=$(du -ah --threshold=1M | awk '/.(JPE?G|jpe?g|PNG|png|HEIC|heic)$/ {print $2}')
+        echo "$img_path"
         if [[ -n "$img_path" ]]; then
           echo "big_image=true" >> $GITHUB_OUTPUT
           echo "img_path=$(echo $img_path)" >> $GITHUB_OUTPUT
         fi
-        
     - name: Install ImageMagick
       if: steps.large-img-check.outputs.big_image == 'true'
       run: |
         cd ..
-        wget https://imagemagick.org/archive/binaries/magick -o /magick
-        chmod +x /magick
+        wget https://imagemagick.org/archive/binaries/magick -o magick
+        chmod +x magick
 
     - name: Shrink images
       if: steps.large-img-check.outputs.big_image == 'true'


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that finds images >1MB, shrinks them in dimension and quality using [ImageMagick](https://imagemagick.org/index.php), and commits them to the repository before the website builds. It attempts to address #8 and the comments in #13.

See it in action here: https://github.com/mhpob/efi-ci-workshop-2024/actions/runs/11520438259
...and the result here: https://github.com/mhpob/efi-ci-workshop-2024/commit/b9648544053aaa6c6055fdface38766155ab91bc

Some of the logic you should be aware of in case it doesn't jive with what you'd like:

- This action currently works on [jpeg, png, and heic files](https://github.com/mhpob/efi-ci-workshop-2024/blob/main/.github/workflows/build-and-deploy.yaml#L27) (these are what I saw in the Google Drive of pictures). Updating the regex here could expand to other types.
- The build/deploy job now [depends on the job added in this PR](https://github.com/mhpob/efi-ci-workshop-2024/blob/main/.github/workflows/build-and-deploy.yaml#L65). It seemed like the issue with large pictures was more with loading the website than the repo, itself, but if the concern is also repo size this could be broken out into its own workflow and apply to all branches, e.g.. I would need to figure out the gymnastics involved to get the website build to wait until image file sizes are reduced.
- Images are shrunk to a [max width/height of 800px](https://github.com/mhpob/efi-ci-workshop-2024/blob/main/.github/workflows/build-and-deploy.yaml#L46). I picked this because the [default width of the body area of the website is 800px](https://quarto.org/docs/output-formats/page-layout.html#html-page-layout). Might be worthwhile to expand the height constraint?
- The original image files are [replaced in the repository](https://github.com/mhpob/efi-ci-workshop-2024/blob/main/.github/workflows/build-and-deploy.yaml#L53) with the down sampled images